### PR TITLE
Embedding version information in a binary file at release

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [tags]
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:
@@ -25,7 +28,6 @@ jobs:
     - name: Generate version file
       run: |
         python .github/workflows/version_embedd.py > version.txt
-      if: startsWith(github.ref, 'refs/tags/')
 
     - name: Build as binary
       run: |
@@ -38,7 +40,6 @@ jobs:
         powershell compress-archive -Path dist/vrc_meta_writer.exe,dist/vrc_meta_reader.exe,dist/user_list_sorter.exe,config.yml,user_list.yml,README.md -DestinationPath dist/vrc_meta_tool.zip
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
       with:
         files: "dist/vrc_meta_tool.zip"
       env:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,12 +21,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip pyyaml psutil
+
+    - name: Generate version file
+      run: |
+        - python .github/workflows/version_embedd.py > version.txt
     - name: Build as binary
       run: |
         python -m pip install PyInstaller
-        pyinstaller.exe vrc_meta_writer.py --version-file ".github/workflows/version_embedd.py" -F
-        pyinstaller.exe vrc_meta_reader.py --version-file ".github/workflows/version_embedd.py" -F
-        pyinstaller.exe user_list_sorter.py --version-file ".github/workflows/version_embedd.py" -F
+        pyinstaller.exe vrc_meta_writer.py --version-file "version.txt" -F
+        pyinstaller.exe vrc_meta_reader.py --version-file "version.txt" -F
+        pyinstaller.exe user_list_sorter.py --version-file "version.txt" -F
     - name: Achive to zip
       run: |
         powershell compress-archive -Path dist/vrc_meta_writer.exe,dist/vrc_meta_reader.exe,dist/user_list_sorter.exe,config.yml,user_list.yml,README.md -DestinationPath dist/vrc_meta_tool.zip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,8 @@ jobs:
     - name: Generate version file
       run: |
         python .github/workflows/version_embedd.py > version.txt
+      if: startsWith(github.ref, 'refs/tags/')
+
     - name: Build as binary
       run: |
         python -m pip install PyInstaller

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Build as binary
       run: |
         python -m pip install PyInstaller
-        pyinstaller.exe vrc_meta_writer.py --version-file "version_embedd.py" -F
-        pyinstaller.exe vrc_meta_reader.py --version-file "version_embedd.py" -F
-        pyinstaller.exe user_list_sorter.py --version-file "version_embedd.py" -F
+        pyinstaller.exe vrc_meta_writer.py --version-file ".github/workflows/version_embedd.py" -F
+        pyinstaller.exe vrc_meta_reader.py --version-file ".github/workflows/version_embedd.py" -F
+        pyinstaller.exe user_list_sorter.py --version-file ".github/workflows/version_embedd.py" -F
     - name: Achive to zip
       run: |
         powershell compress-archive -Path dist/vrc_meta_writer.exe,dist/vrc_meta_reader.exe,dist/user_list_sorter.exe,config.yml,user_list.yml,README.md -DestinationPath dist/vrc_meta_tool.zip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [tags]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Build as binary
       run: |
         python -m pip install PyInstaller
-        pyinstaller.exe vrc_meta_writer.py -F
-        pyinstaller.exe vrc_meta_reader.py -F
-        pyinstaller.exe user_list_sorter.py -F
+        pyinstaller.exe vrc_meta_writer.py --version-file "version_embedd.py" -F
+        pyinstaller.exe vrc_meta_reader.py --version-file "version_embedd.py" -F
+        pyinstaller.exe user_list_sorter.py --version-file "version_embedd.py" -F
     - name: Achive to zip
       run: |
         powershell compress-archive -Path dist/vrc_meta_writer.exe,dist/vrc_meta_reader.exe,dist/user_list_sorter.exe,config.yml,user_list.yml,README.md -DestinationPath dist/vrc_meta_tool.zip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Generate version file
       run: |
-        - python .github/workflows/version_embedd.py > version.txt
+        python .github/workflows/version_embedd.py > version.txt
     - name: Build as binary
       run: |
         python -m pip install PyInstaller

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -1,13 +1,16 @@
 import os
 import re
 
-commitHash = os.environ.get("GITHUB_SHA")
+commit_hash = os.environ.get("GITHUB_SHA")
 version_number = []
-pattern = re.compile('.*v([0-9]+)\.([0-9]+).([0-9]+).')
+pattern = re.compile(".*v([0-9]+)\.([0-9]+).([0-9]+).")
 version_number = re.match(pattern, os.environ.get("GITHUB_REF")).groups()
-version_number_str = "{}.{}.{}".format(version_number[0], version_number[1], version_number[2])
+version_number_str = "{}.{}.{}".format(
+    version_number[0], version_number[1], version_number[2]
+)
 
-print(f'''
+print(
+    f"""
 VSVersionInfo(
   ffi=FixedFileInfo(
     filevers=({version_number[0]}, {version_number[1]}, {version_number[2]}, 0),
@@ -34,9 +37,10 @@ VSVersionInfo(
         StringStruct(u'ProductVersion', u'{version_number_str}'),
         StringStruct(u'CompanyShortName', u'None'),
         StringStruct(u'ProductShortName', u'vrc_meta_tool'),
-        StringStruct(u'LastChange', u'{commitHash}'),
+        StringStruct(u'LastChange', u'{commit_hash}'),
         StringStruct(u'Official Build', u'1')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]
-)''')
+)"""
+)

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -1,0 +1,48 @@
+import os
+
+version = os.environ.get("GITHUB_SHA")
+
+print(f'''
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
+    # Set not needed items to zero 0.
+    filevers=(78, 0, 3904, 108),
+    prodvers=(78, 0, 3904, 108),
+    # Contains a bitmask that specifies the valid bits 'flags'r
+    mask=0x17,
+    # Contains a bitmask that specifies the Boolean attributes of the file.
+    flags=0x0,
+    # The operating system for which this file was designed.
+    # 0x4 - NT and there is no need to change it.
+    OS=0x4,
+    # The general type of file.
+    # 0x1 - the file is an application.
+    fileType=0x1,
+    # The function of the file.
+    # 0x0 - the function is not defined for this fileType
+    subtype=0x0,
+    # Creation date and time stamp.
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        u'040904b0',
+        [StringStruct(u'CompanyName', u'None'),
+        StringStruct(u'FileDescription', u'vrc_meta_tool'),
+        StringStruct(u'FileVersion', u'{version}'),
+        StringStruct(u'InternalName', u'vrc_meta_tool'),
+        StringStruct(u'LegalCopyright', u'Copyright 2020 vrc_meta_tool. All rights reserved.'),
+        StringStruct(u'OriginalFilename', u'vrc_meta_tool'),
+        StringStruct(u'ProductName', u'vrc_meta_tool'),
+        StringStruct(u'ProductVersion', u'{version}'),
+        StringStruct(u'CompanyShortName', u'None'),
+        StringStruct(u'ProductShortName', u'vrc_meta_tool'),
+        StringStruct(u'LastChange', u'{version}'),
+        StringStruct(u'Official Build', u'1')])
+      ]),
+    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+  ]
+)''')

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -1,14 +1,19 @@
 import os
+import re
 
 version = os.environ.get("GITHUB_SHA")
+version_number = []
+pattern = re.compile('.*v([0-9]+)\.([0-9]+).([0-9]+).')
+version_number = re.match(pattern, os.environ.get("GITHUB_REF")).groups()
+version_number_str = "{}.{}.{}".format(version_number[0], version_number[1], version_number[2])
 
 print(f'''
 VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    # filevers=({version}),
-    # prodvers=({version}),
+    filevers=({version_number[0]}, {version_number[1]}, {version_number[2]}),
+    prodvers=({version_number[0]}, {version_number[1]}, {version_number[2]}),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x17,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -32,12 +37,12 @@ VSVersionInfo(
         u'040904b0',
         [StringStruct(u'CompanyName', u'None'),
         StringStruct(u'FileDescription', u'vrc_meta_tool'),
-        StringStruct(u'FileVersion', u'{version}'),
+        StringStruct(u'FileVersion', u'{version_number_str}'),
         StringStruct(u'InternalName', u'vrc_meta_tool'),
         StringStruct(u'LegalCopyright', u'Copyright 2020 vrc_meta_tool. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'vrc_meta_tool'),
         StringStruct(u'ProductName', u'vrc_meta_tool'),
-        StringStruct(u'ProductVersion', u'{version}'),
+        StringStruct(u'ProductVersion', u'{version_number_str}'),
         StringStruct(u'CompanyShortName', u'None'),
         StringStruct(u'ProductShortName', u'vrc_meta_tool'),
         StringStruct(u'LastChange', u'{version}'),

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(78, 0, 3904, 108),
-    prodvers=(78, 0, 3904, 108),
+    filevers=({version}),
+    prodvers=({version}),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x17,
     # Contains a bitmask that specifies the Boolean attributes of the file.

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-version = os.environ.get("GITHUB_SHA")
+commitHash = os.environ.get("GITHUB_SHA")
 version_number = []
 pattern = re.compile('.*v([0-9]+)\.([0-9]+).([0-9]+).')
 version_number = re.match(pattern, os.environ.get("GITHUB_REF")).groups()
@@ -34,7 +34,7 @@ VSVersionInfo(
         StringStruct(u'ProductVersion', u'{version_number_str}'),
         StringStruct(u'CompanyShortName', u'None'),
         StringStruct(u'ProductShortName', u'vrc_meta_tool'),
-        StringStruct(u'LastChange', u'{version}'),
+        StringStruct(u'LastChange', u'{commitHash}'),
         StringStruct(u'Official Build', u'1')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -10,24 +10,13 @@ version_number_str = "{}.{}.{}".format(version_number[0], version_number[1], ver
 print(f'''
 VSVersionInfo(
   ffi=FixedFileInfo(
-    # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
-    # Set not needed items to zero 0.
-    filevers=({version_number[0]}, {version_number[1]}, {version_number[2]}),
-    prodvers=({version_number[0]}, {version_number[1]}, {version_number[2]}),
-    # Contains a bitmask that specifies the valid bits 'flags'r
+    filevers=({version_number[0]}, {version_number[1]}, {version_number[2]}, 0),
+    prodvers=({version_number[0]}, {version_number[1]}, {version_number[2]}, 0),
     mask=0x17,
-    # Contains a bitmask that specifies the Boolean attributes of the file.
     flags=0x0,
-    # The operating system for which this file was designed.
-    # 0x4 - NT and there is no need to change it.
     OS=0x4,
-    # The general type of file.
-    # 0x1 - the file is an application.
     fileType=0x1,
-    # The function of the file.
-    # 0x0 - the function is not defined for this fileType
     subtype=0x0,
-    # Creation date and time stamp.
     date=(0, 0)
     ),
   kids=[

--- a/.github/workflows/version_embedd.py
+++ b/.github/workflows/version_embedd.py
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=({version}),
-    prodvers=({version}),
+    # filevers=({version}),
+    # prodvers=({version}),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x17,
     # Contains a bitmask that specifies the Boolean attributes of the file.


### PR DESCRIPTION
https://github.com/bootjp/vrc_meta_tool/releases/tag/v2.5.14-beta

![unknown](https://user-images.githubusercontent.com/1306365/82730134-7ed77400-9d38-11ea-9a1b-07dac78972b4.png)

## Other changes
- github action build is tag push only 
